### PR TITLE
fix azuread_application_password argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,6 @@ resource "azurerm_role_assignment" "main" {
 
 // Create a password (client secret) for the Azure AD application.
 resource "azuread_application_password" "main" {
-  application_object_id = azuread_application.main.object_id
+  application_id = azuread_application.main.object_id
   end_date_relative     = "8640h"
 }


### PR DESCRIPTION
When bumping **azuread** from >= 2.28.1 to >= 2.49.1 forgot to change **azuread_application_password** argument `application_object_id` to `application_id`

https://registry.terraform.io/providers/hashicorp/azuread/2.49.1/docs/resources/application_password

https://github.com/isovalent/terraform-azure-service-principal/pull/1

So getting:
```
│ Error: Missing required argument
│ 
│   on .terraform/modules/aks.cilium_service_principal/main.tf line 54, in resource "azuread_application_password" "main":
│   54: resource "azuread_application_password" "main" {
│ 
│ The argument "application_id" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/aks.cilium_service_principal/main.tf line 55, in resource "azuread_application_password" "main":
│   55:   application_object_id = azuread_application.main.object_id
│ 
│ An argument named "application_object_id" is not expected here.
╵
```