### PR TITLE
fix azuread_application_password and azurerm_role_assignment args

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,13 +45,13 @@ resource "azuread_service_principal" "main" {
 
 // Create role assignment for the Azure AD service principal.
 resource "azurerm_role_assignment" "main" {
-  principal_id         = azuread_service_principal.main.id
+  principal_id         = azuread_service_principal.main.object_id
   role_definition_name = var.role
   scope                = data.azurerm_subscription.main.id
 }
 
 // Create a password (client secret) for the Azure AD application.
 resource "azuread_application_password" "main" {
-  application_id = azuread_application.main.object_id
+  application_id = azuread_application.main.id
   end_date_relative     = "8640h"
 }


### PR DESCRIPTION
to fix:
```
╷
│ Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidPrincipalId" Message="The Principal ID '/servicePrincipals/5b431b2c-6fb3-444e-980c-4d488b201116' is not valid. Principal ID must be a GUID."
│ 
│   with module.aks.module.cilium_service_principal[0].azurerm_role_assignment.main,
│   on .terraform/modules/aks.cilium_service_principal/main.tf line 47, in resource "azurerm_role_assignment" "main":
│   47: resource "azurerm_role_assignment" "main" {

```
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment
https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password